### PR TITLE
add deployment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ resources.
 - [Libraries](#libraries)
 - [Transformation](#transformation)
 - [Implementations](#implementations)
+- [Deployment](#deployment)
 - [Resources](#resources)
   - [Documentation](#documentation)
   - [Examples](#examples)
@@ -59,6 +60,11 @@ resources.
   Cloud data warehouse with support for managed DuckLake
 - [DataFusion-DuckLake](https://crates.io/crates/datafusion-ducklake) - DuckLake
   query engine for Rust, built with DataFusion.
+
+## Deployment
+
+- [ducklake-deploy](https://github.com/berndsen-io/ducklake-deploy) - Deploy
+  DuckLake on Hetzner, Scaleway, or AWS with OpenTofu
 
 ## Resources
 


### PR DESCRIPTION
adds a deployment section with ducklake-deploy for getting ducklake running on hetzner, scaleway, or aws with opentofu.