### PR TITLE
Add SwanLake to Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ resources.
   Cloud data warehouse with support for managed DuckLake
 - [DataFusion-DuckLake](https://crates.io/crates/datafusion-ducklake) - DuckLake
   query engine for Rust, built with DataFusion.
+- [SwanLake](https://github.com/swanlake-io/swanlake) - Arrow Flight SQL server
+  backed by DuckDB, with DuckLake support
 
 ## Resources
 


### PR DESCRIPTION
Adds [SwanLake](https://github.com/swanlake-io/swanlake) — an Arrow Flight SQL server backed by DuckDB with DuckLake support — to the Implementations section.