### PR TITLE
Add duckgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A curated list of awesome [DuckLake](https://ducklake.select/) tools and resourc
 - [DataFusion-DuckLake](https://crates.io/crates/datafusion-ducklake) - DuckLake query engine for Rust, built with DataFusion.
 - [SwanLake](https://github.com/swanlake-io/swanlake) - Arrow Flight SQL server backed by DuckDB, with DuckLake support
 - [pg_ducklake](https://github.com/relytcloud/pg_ducklake) - Postgres extension for managing DuckLake database
+- [duckgres](https://github.com/PostHog/duckgres) - Postgres-speaking server backed by DuckDB that underpins [Posthog's managed warehouse](https://posthog.com/data-stack/managed-warehouse)
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A curated list of awesome [DuckLake](https://ducklake.select/) tools and resourc
 - [DataFusion-DuckLake](https://crates.io/crates/datafusion-ducklake) - DuckLake query engine for Rust, built with DataFusion.
 - [SwanLake](https://github.com/swanlake-io/swanlake) - Arrow Flight SQL server backed by DuckDB, with DuckLake support
 - [pg_ducklake](https://github.com/relytcloud/pg_ducklake) - Postgres extension for managing DuckLake database
-- [duckgres](https://github.com/PostHog/duckgres) - Postgres-speaking server backed by DuckDB that underpins [Posthog's managed warehouse](https://posthog.com/data-stack/managed-warehouse)
+- [duckgres](https://github.com/PostHog/duckgres) - Postgres-speaking server backed by DuckDB that underpins [Posthog's Ducklake-based managed warehouse](https://posthog.com/data-stack/managed-warehouse)
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A curated list of awesome [DuckLake](https://ducklake.select/) tools and resourc
 - [DataFusion-DuckLake](https://crates.io/crates/datafusion-ducklake) - DuckLake query engine for Rust, built with DataFusion.
 - [SwanLake](https://github.com/swanlake-io/swanlake) - Arrow Flight SQL server backed by DuckDB, with DuckLake support
 - [pg_ducklake](https://github.com/relytcloud/pg_ducklake) - Postgres extension for managing DuckLake database
-- [duckgres](https://github.com/PostHog/duckgres) - Postgres-speaking server backed by DuckDB that underpins [Posthog's Ducklake-based managed warehouse](https://posthog.com/data-stack/managed-warehouse)
+- [duckgres](https://github.com/PostHog/duckgres) - Postgres-speaking server backed by DuckDB that underpins [PostHog's Ducklake-based managed warehouse](https://posthog.com/data-stack/managed-warehouse)
 
 ## Resources
 


### PR DESCRIPTION
Duckgres is a Postgres-compatible DuckDB/Ducklake server.